### PR TITLE
fix: corrige tratamento de timestamps para UTC no PostgreSQL

### DIFF
--- a/MecanicaOS/Aplicacao/Servicos/ServicoServico.cs
+++ b/MecanicaOS/Aplicacao/Servicos/ServicoServico.cs
@@ -90,7 +90,7 @@ namespace Aplicacao.Servicos
                 if (servico.Disponivel != novoServico.Disponivel)
                     servico.Disponivel = novoServico.Disponivel;
 
-                servico.DataAtualizacao = DateTime.Now;
+                servico.DataAtualizacao = DateTime.UtcNow;
 
                 await _repositorio.Editar(servico);
 


### PR DESCRIPTION
- Altera DataCadastro para usar DateTime.UtcNow
- Torna DataAtualizacao nullable (DateTime?)
- Garante compatibilidade com PostgreSQL timestamp with time zone