### PR TITLE
fix: Adiciona fetch-depth: 0 ao checkout no job create-pr

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,6 +38,8 @@ jobs:
       pull-requests: write
     steps:
       - uses: actions/checkout@v3
+        with:
+          fetch-depth: 0
 
       - name: Criar Pull Request para main
         uses: peter-evans/create-pull-request@v3


### PR DESCRIPTION
O job de criação de Pull Request estava falhando porque o clone superficial do repositório não continha a referência para a branch 'main'. Adicionar 'fetch-depth: 0' garante que o histórico completo do Git seja baixado, resolvendo o erro 'fatal: couldn't find remote ref main'.